### PR TITLE
Remove stray MAPSEC_DYNAMIC entries

### DIFF
--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -4924,14 +4924,6 @@
       "width": 1,
       "x": 23,
       "y": 5
-    },
-    {
-      "height": 1,
-      "map_section": "MAPSEC_DYNAMIC",
-      "name": "",
-      "width": 1,
-      "x": 0,
-      "y": 0
     }
   ],
   "map_sections_kanto": [
@@ -6942,14 +6934,6 @@
       "width": 1,
       "x": 0,
       "y": 0
-    },
-    {
-      "height": 1,
-      "map_section": "MAPSEC_DYNAMIC",
-      "name": "",
-      "width": 1,
-      "x": 0,
-      "y": 0
     }
   ],
   "map_sections_sevii": [
@@ -8957,14 +8941,6 @@
       "height": 1,
       "map_section": "MAPSEC_MT_SILVER",
       "name": "MT. SILVER",
-      "width": 1,
-      "x": 0,
-      "y": 0
-    },
-    {
-      "height": 1,
-      "map_section": "MAPSEC_DYNAMIC",
-      "name": "",
       "width": 1,
       "x": 0,
       "y": 0


### PR DESCRIPTION
## Summary
- remove spurious MAPSEC_DYNAMIC records from `region_map_sections.json` to prevent undefined map name references during build

## Testing
- `make build/modern/src/region_map.o`

------
https://chatgpt.com/codex/tasks/task_e_68a4d74b165c832389a8d0cad0b9cf95