### PR TITLE
Fix region map template for map entry generation

### DIFF
--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -9339,5 +9339,31 @@
       "x": 9,
       "y": 0
     }
+  ],
+  "map_sections_sinnoh": [
+    {
+      "height": 1,
+      "map_section": "MAPSEC_TWINLEAF_TOWN",
+      "name": "TWINLEAF TOWN",
+      "width": 1,
+      "x": 2,
+      "y": 14
+    },
+    {
+      "height": 1,
+      "map_section": "MAPSEC_SANDGEM_TOWN",
+      "name": "SANDGEM TOWN",
+      "width": 1,
+      "x": 4,
+      "y": 13
+    },
+    {
+      "height": 1,
+      "map_section": "MAPSEC_JUBILIFE_CITY",
+      "name": "JUBILIFE CITY",
+      "width": 2,
+      "x": 3,
+      "y": 11
+    }
   ]
 }

--- a/src/data/region_map/region_map_sections.json.txt
+++ b/src/data/region_map/region_map_sections.json.txt
@@ -4,13 +4,13 @@
 
 ## for map_section in map_sections
 {% if existsIn(map_section, "name") %}
-{% if isEmptyString(getVar(map_section.name)) and not existsIn(map_section, "name_clone") %}{{ setVar(map_section.name, map_section.map_section) }}{% endif %}
+{% if isEmptyString(getVar(map_section.name)) and not existsIn(map_section, "name_clone") %}{% if existsIn(map_section, "map_section") %}{{ setVar(map_section.name, map_section.map_section) }}{% else %}{{ setVar(map_section.name, map_section.id) }}{% endif %}{% endif %}
 {% endif %}
 ## endfor
 
 ## for map_section in map_sections
 {% if existsIn(map_section, "name") %}
-{% if getVar(map_section.name) == map_section.map_section %}
+{% if existsIn(map_section, "map_section") and getVar(map_section.name) == map_section.map_section or (not existsIn(map_section, "map_section") and getVar(map_section.name) == map_section.id) %}
 static const u8 sMapName_{{ cleanString(map_section.name) }}[] = _("{{ map_section.name }}");
 {% endif %}
 {% if existsIn(map_section, "name_clone") %}
@@ -26,28 +26,6 @@ const struct RegionMapLocation gRegionMapEntries[] = {
         .x = {{ map_section.x }},
 {% else %}
         .x = 0,
-
-const struct RegionMapLocation gRegionMapEntries_Johto[] = {
-## for map_section in map_sections_johto
-{% if existsIn(map_section, "name") %}
-    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
-{% endif %}
-## endfor
-};
-
-const struct RegionMapLocation gRegionMapEntries_Kanto[] = {
-## for map_section in map_sections_kanto
-{% if existsIn(map_section, "name") %}
-    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
-{% endif %}
-## endfor
-};
-
-const struct RegionMapLocation gRegionMapEntries_Sevii[] = {
-## for map_section in map_sections_sevii
-{% if existsIn(map_section, "name") %}
-    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
-
 {% endif %}
 {% if existsIn(map_section, "y") %}
         .y = {{ map_section.y }},
@@ -70,6 +48,38 @@ const struct RegionMapLocation gRegionMapEntries_Sevii[] = {
         .name = (const u8[])_(""),
 {% endif %}
     },
+## endfor
+};
+
+const struct RegionMapLocation gRegionMapEntries_Johto[] = {
+## for map_section in map_sections_johto
+{% if existsIn(map_section, "name") %}
+    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
+## endfor
+};
+
+const struct RegionMapLocation gRegionMapEntries_Kanto[] = {
+## for map_section in map_sections_kanto
+{% if existsIn(map_section, "name") %}
+    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
+## endfor
+};
+
+const struct RegionMapLocation gRegionMapEntries_Sevii[] = {
+## for map_section in map_sections_sevii
+{% if existsIn(map_section, "name") %}
+    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
+## endfor
+};
+
+const struct RegionMapLocation gRegionMapEntries_Sinnoh[] = {
+## for map_section in map_sections_sinnoh
+{% if existsIn(map_section, "name") %}
+    [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
 ## endfor
 };
 


### PR DESCRIPTION
## Summary
- rework `region_map_sections.json.txt` to properly close conditionals and separate region arrays
- handle map sections without `map_section` field when building name maps
- add Sinnoh region map entries and sections data

## Testing
- `tools/jsonproc/jsonproc src/data/region_map/region_map_sections.json src/data/region_map/region_map_sections.json.txt src/data/region_map/region_map_entries.h`
- `make` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a67999d9fc832388489d4ff7095c7c