### PR TITLE
Fix Jubilife map references to build

### DIFF
--- a/data/layouts/layouts.json
+++ b/data/layouts/layouts.json
@@ -10857,7 +10857,7 @@
       "width": 64,
       "height": 32,
       "primary_tileset": "gTileset_SinnohGeneral",
-      "secondary_tileset": "gTileset_Jubilife",
+      "secondary_tileset": "gTileset_JubilifeCitySecondary",
       "border_filepath": "data/layouts/Route207/border.bin",
       "blockdata_filepath": "data/layouts/Route207/map.bin"
     },
@@ -10917,7 +10917,7 @@
       "width": 36,
       "height": 28,
       "primary_tileset": "gTileset_SinnohGeneral",
-      "secondary_tileset": "gTileset_Jubilife",
+      "secondary_tileset": "gTileset_JubilifeCitySecondary",
       "border_filepath": "data/layouts/Route211_West/border.bin",
       "blockdata_filepath": "data/layouts/Route211_West/map.bin"
     },
@@ -10997,7 +10997,7 @@
       "width": 64,
       "height": 32,
       "primary_tileset": "gTileset_SinnohGeneral",
-      "secondary_tileset": "gTileset_Jubilife",
+      "secondary_tileset": "gTileset_JubilifeCitySecondary",
       "border_filepath": "data/layouts/Route218/border.bin",
       "blockdata_filepath": "data/layouts/Route218/map.bin"
     },
@@ -11227,7 +11227,7 @@
       "width": 24,
       "height": 26,
       "primary_tileset": "gTileset_SinnohGeneral",
-      "secondary_tileset": "gTileset_Jubilife",
+      "secondary_tileset": "gTileset_JubilifeCitySecondary",
       "border_filepath": "data/layouts/OreburghMine_B1F/border.bin",
       "blockdata_filepath": "data/layouts/OreburghMine_B1F/map.bin"
     },

--- a/data/maps/JubilifeCity/map.json
+++ b/data/maps/JubilifeCity/map.json
@@ -2,7 +2,7 @@
   "id": "MAP_JUBILIFE_CITY",
   "name": "JubilifeCity",
   "layout": "LAYOUT_JUBILIFE_CITY",
-  "music": "MUS_DP_JUBILIFE_DAY",
+  "music": "MUS_LITTLEROOT",
   "region_map_section": "MAPSEC_JUBILIFE_CITY",
   "requires_flash": false,
   "weather": "WEATHER_NONE",


### PR DESCRIPTION
## Summary
- Replace outdated `gTileset_Jubilife` usage in several layouts with `gTileset_JubilifeCitySecondary`
- Use existing `MUS_LITTLEROOT` for Jubilife City map music to avoid undefined symbol

## Testing
- `make -j2` *(fails: Cannot open file data/maps//NavelRock_Peak/map.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0e0ba0e48323bc9229e7c8193ce3