### PR TITLE
Fix missing region map names

### DIFF
--- a/data/maps/SendOffSpring/map.json
+++ b/data/maps/SendOffSpring/map.json
@@ -3,7 +3,7 @@
   "name": "SendOffSpring",
   "layout": "LAYOUT_SEND_OFF_SPRING",
   "music": "MUS_EVER_GRANDE",
-  "region_map_section": "MAPSEC_ROUTE_214",
+  "region_map_section": "MAPSEC_SENDOFF_SPRING",
   "requires_flash": false,
   "weather": "WEATHER_SUNNY",
   "map_type": "MAP_TYPE_ROUTE",

--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -2376,12 +2376,21 @@
     },
     {
       "id": "MAPSEC_ROUTE_214",
-      "name": "Send Off Spring",
+      "name": "ROUTE 214",
       "x": 17,
       "y": 9,
       "width": 1,
       "height": 2,
       "map_section": "MAPSEC_ROUTE_214"
+    },
+    {
+      "id": "MAPSEC_SENDOFF_SPRING",
+      "name": "SENDOFF SPRING",
+      "x": 17,
+      "y": 10,
+      "width": 1,
+      "height": 1,
+      "map_section": "MAPSEC_SENDOFF_SPRING"
     },
     {
       "id": "MAPSEC_ROUTE_213",
@@ -2538,12 +2547,21 @@
     },
     {
       "id": "MAPSEC_HEARTHOME_CITY",
-      "name": "AMITY SQUARE",
+      "name": "HEARTHOME CITY",
       "x": 11,
       "y": 10,
       "width": 2,
       "height": 1,
       "map_section": "MAPSEC_HEARTHOME_CITY"
+    },
+    {
+      "id": "MAPSEC_AMITY_SQUARE",
+      "name": "AMITY SQUARE",
+      "x": 11,
+      "y": 10,
+      "width": 1,
+      "height": 1,
+      "map_section": "MAPSEC_AMITY_SQUARE"
     },
     {
       "id": "MAPSEC_ETERNA_CITY",


### PR DESCRIPTION
## Summary
- Correct region map section names for Hearthome City and Route 214
- Declare Amity Square and Sendoff Spring region map sections and assign Sendoff Spring's map to its section

## Testing
- `tools/jsonproc/jsonproc src/data/region_map/region_map_sections.json src/data/region_map/region_map_sections.json.txt /tmp/region_map_entries.h`
- `make src/data/region_map/region_map_entries.h`


------
https://chatgpt.com/codex/tasks/task_e_68ae7c6bf4488323bb1e696bfb40215d