### PR TITLE
Remove undefined Amity Square connection from Hearthome City

### DIFF
--- a/data/maps/HearthomeCity/map.json
+++ b/data/maps/HearthomeCity/map.json
@@ -27,11 +27,6 @@
       "map": "MAP_ROUTE212_NORTH",
       "offset": 2,
       "direction": "down"
-    },
-    {
-      "map": "MAP_AMITY_SQUARE",
-      "offset": 0,
-      "direction": "up"
     }
   ],
   "object_events": [],


### PR DESCRIPTION
## Summary
- fix assembly error by removing connection to undefined `MAP_AMITY_SQUARE`

## Testing
- `tools/mapjson/mapjson map emerald data/maps/HearthomeCity/map.json data/layouts/layouts.json data/maps/HearthomeCity`
- `make build/modern/data/maps.o` *(fails: required tool build process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8400e0108323a65507a3b61e9df7