### PR TITLE
Add missing map script stubs

### DIFF
--- a/data/maps/EternaForestA/scripts.inc
+++ b/data/maps/EternaForestA/scripts.inc
@@ -1,0 +1,2 @@
+EternaForestA_MapScripts::
+	.byte 0

--- a/data/maps/LakeAcuityCave/scripts.inc
+++ b/data/maps/LakeAcuityCave/scripts.inc
@@ -1,0 +1,2 @@
+LakeAcuityCave_MapScripts::
+	.byte 0

--- a/data/maps/LakeValorCave/scripts.inc
+++ b/data/maps/LakeValorCave/scripts.inc
@@ -1,0 +1,2 @@
+LakeValorCave_MapScripts::
+	.byte 0

--- a/data/maps/LakeVerityCave/scripts.inc
+++ b/data/maps/LakeVerityCave/scripts.inc
@@ -1,0 +1,2 @@
+LakeVerityCave_MapScripts::
+	.byte 0

--- a/data/maps/OreburghCityA/scripts.inc
+++ b/data/maps/OreburghCityA/scripts.inc
@@ -1,0 +1,2 @@
+OreburghCityA_MapScripts::
+	.byte 0

--- a/data/maps/OreburghGate2F/scripts.inc
+++ b/data/maps/OreburghGate2F/scripts.inc
@@ -1,0 +1,2 @@
+OreburghGate2F_MapScripts::
+	.byte 0


### PR DESCRIPTION
## Summary
- add empty `scripts.inc` for LakeVerityCave, LakeAcuityCave, LakeValorCave, OreburghCityA, OreburghGate2F, and EternaForestA to unblock event script builds

## Testing
- `make build/modern/data/event_scripts.o`


------
https://chatgpt.com/codex/tasks/task_e_68ae86b0ace08323994ff81d8b8f4724