### PR TITLE
Convert QoL submenus to scrollable lists

### DIFF
--- a/data/scripts/qol_scientist.inc
+++ b/data/scripts/qol_scientist.inc
@@ -62,13 +62,16 @@ EventScript_QoLScientist::
     goto .MainLoop
 
 .DoEVs:
-	multichoice 15, 1, MULTI_QOL_EVS, FALSE
-	switch VAR_RESULT
-		case 0, .EV_Preset
-		case 1, .EV_Quick
-		case 2, .EV_Full
-		case 3, .EV_Clear
-		case 4, .MainLoop
+        setvar VAR_0x8004, SCROLL_MULTI_QOL_EVS
+        special ShowScrollableMultichoice
+        waitstate
+        switch VAR_RESULT
+                case 0, .EV_Preset
+                case 1, .EV_Quick
+                case 2, .EV_Full
+                case 3, .EV_Clear
+                case 4, .MainLoop
+                case MULTI_B_PRESSED, .MainLoop
 
 .EV_Preset:
     msgbox gText_QoLChooseMon, MSGBOX_DEFAULT
@@ -85,18 +88,26 @@ EventScript_QoLScientist::
     waitstate
     goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, .DoEVs
     msgbox gText_QoLPickStat1, MSGBOX_DEFAULT
-    multichoice 15, 1, MULTI_QOL_STATS, FALSE
+    setvar VAR_0x8004, SCROLL_MULTI_QOL_STATS
+    special ShowScrollableMultichoice
+    waitstate
     compare VAR_RESULT, 6
     goto_if_eq .DoEVs
+    compare VAR_RESULT, MULTI_B_PRESSED
+    goto_if_eq .DoEVs
     setvar VAR_0x8000, VAR_RESULT
-	msgbox gText_QoLPickStat2, MSGBOX_DEFAULT
-	multichoice 0, 0, MULTI_QOL_STATS, FALSE
-	compare VAR_RESULT, 6
-	goto_if_eq .DoEVs
-	setvar VAR_0x8001, VAR_RESULT
-	callnative Script_QoL_EVs_QuickCustom
-	call .ResultMsg
-	goto .DoEVs
+        msgbox gText_QoLPickStat2, MSGBOX_DEFAULT
+        setvar VAR_0x8004, SCROLL_MULTI_QOL_STATS
+        special ShowScrollableMultichoice
+        waitstate
+        compare VAR_RESULT, 6
+        goto_if_eq .DoEVs
+        compare VAR_RESULT, MULTI_B_PRESSED
+        goto_if_eq .DoEVs
+        setvar VAR_0x8001, VAR_RESULT
+        callnative Script_QoL_EVs_QuickCustom
+        call .ResultMsg
+        goto .DoEVs
 
 .EV_Full:
     msgbox gText_QoLChooseMon, MSGBOX_DEFAULT
@@ -145,12 +156,15 @@ EventScript_QoLScientist::
     goto .DoEVs
 
 .DoIVs:
-	multichoice 15, 1, MULTI_QOL_IVS, FALSE
-	switch VAR_RESULT
-		case 0, .IV_31
-		case 1, .IV_TR
-		case 2, .IV_SetStat
-		case 3, .MainLoop
+        setvar VAR_0x8004, SCROLL_MULTI_QOL_IVS
+        special ShowScrollableMultichoice
+        waitstate
+        switch VAR_RESULT
+                case 0, .IV_31
+                case 1, .IV_TR
+                case 2, .IV_SetStat
+                case 3, .MainLoop
+                case MULTI_B_PRESSED, .MainLoop
 
 .IV_31:
     msgbox gText_QoLChooseMon, MSGBOX_DEFAULT
@@ -172,8 +186,12 @@ EventScript_QoLScientist::
 
 .IV_SetStat:
     msgbox gText_QoLPickAStat, MSGBOX_DEFAULT
-    multichoice 15, 1, MULTI_QOL_STATS, FALSE
+    setvar VAR_0x8004, SCROLL_MULTI_QOL_STATS
+    special ShowScrollableMultichoice
+    waitstate
     compare VAR_RESULT, 6
+    goto_if_eq .DoIVs
+    compare VAR_RESULT, MULTI_B_PRESSED
     goto_if_eq .DoIVs
     setvar VAR_0x8000, VAR_RESULT        @ store chosen stat
     copyvar VAR_0x8003, VAR_0x8000       @ preserve stat across number prompt
@@ -196,21 +214,25 @@ EventScript_QoLScientist::
     special ChoosePartyMon
     waitstate
     goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, .MainLoop
-	msgbox gText_QoLPickBall, MSGBOX_DEFAULT
-	multichoice 0, 0, MULTI_QOL_BALLS, FALSE
-	compare VAR_RESULT, 10
-	goto_if_eq .MainLoop
-	switch VAR_RESULT
-		case 0, .B0
-		case 1, .B1
-		case 2, .B2
-		case 3, .B3
-		case 4, .B4
-		case 5, .B5
-		case 6, .B6
-		case 7, .B7
-		case 8, .B8
-		case 9, .B9
+        msgbox gText_QoLPickBall, MSGBOX_DEFAULT
+        setvar VAR_0x8004, SCROLL_MULTI_QOL_BALLS
+        special ShowScrollableMultichoice
+        waitstate
+        compare VAR_RESULT, 10
+        goto_if_eq .MainLoop
+        compare VAR_RESULT, MULTI_B_PRESSED
+        goto_if_eq .MainLoop
+        switch VAR_RESULT
+                case 0, .B0
+                case 1, .B1
+                case 2, .B2
+                case 3, .B3
+                case 4, .B4
+                case 5, .B5
+                case 6, .B6
+                case 7, .B7
+                case 8, .B8
+                case 9, .B9
 .B0: setvar VAR_0x8000, ITEM_POKE_BALL;    goto .BApply
 .B1: setvar VAR_0x8000, ITEM_GREAT_BALL;   goto .BApply
 .B2: setvar VAR_0x8000, ITEM_ULTRA_BALL;   goto .BApply

--- a/include/constants/field_specials.h
+++ b/include/constants/field_specials.h
@@ -55,6 +55,10 @@
 #define SCROLL_MULTI_SS_TIDAL_SEVII_DESTINATION5          25
 #define SCROLL_MULTI_SS_TIDAL_SEVII_DESTINATION6          26
 #define SCROLL_MULTI_SS_TIDAL_SEVII_DESTINATION7          27
+#define SCROLL_MULTI_QOL_EVS                              28
+#define SCROLL_MULTI_QOL_IVS                              29
+#define SCROLL_MULTI_QOL_STATS                            30
+#define SCROLL_MULTI_QOL_BALLS                            31
 
 #define MAX_SCROLL_MULTI_ON_SCREEN 6
 #define MAX_SCROLL_MULTI_LENGTH 16

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2601,6 +2601,46 @@ void ShowScrollableMultichoice(void)
         task->tKeepOpenAfterSelect = FALSE;
         task->tTaskId = taskId;
         break;
+    case SCROLL_MULTI_QOL_EVS:
+        task->tMaxItemsOnScreen = 5;
+        task->tNumItems = 5;
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_QOL_IVS:
+        task->tMaxItemsOnScreen = 4;
+        task->tNumItems = 4;
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_QOL_STATS:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 7;
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_QOL_BALLS:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 11;
+        task->tLeft = 0;
+        task->tTop = 0;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
     default:
         gSpecialVar_Result = MULTI_B_PRESSED;
         DestroyTask(taskId);
@@ -2935,6 +2975,45 @@ static const u8 *const sScrollableMultichoiceOptions[][MAX_SCROLL_MULTI_LENGTH] 
         COMPOUND_STRING("FAIRY{CLEAR_TO 0x48}¥1000"),
         COMPOUND_STRING("STELLAR{CLEAR_TO 0x48}¥5000"),
         COMPOUND_STRING("BACK")
+    },
+    [SCROLL_MULTI_QOL_EVS] =
+    {
+        COMPOUND_STRING("Preset by nature"),
+        COMPOUND_STRING("Quick: 252/252/6"),
+        COMPOUND_STRING("Full custom"),
+        COMPOUND_STRING("Clear EVs"),
+        gText_Exit
+    },
+    [SCROLL_MULTI_QOL_IVS] =
+    {
+        COMPOUND_STRING("Perfect 31"),
+        COMPOUND_STRING("Trick Room: 0 Spe"),
+        COMPOUND_STRING("Set IV"),
+        gText_Exit
+    },
+    [SCROLL_MULTI_QOL_STATS] =
+    {
+        gText_HP4,
+        gText_Attack3,
+        gText_Defense3,
+        gText_Speed2,
+        gText_SpAtk4,
+        gText_SpDef4,
+        gText_Exit
+    },
+    [SCROLL_MULTI_QOL_BALLS] =
+    {
+        COMPOUND_STRING("POKé BALL"),
+        COMPOUND_STRING("GREAT BALL"),
+        COMPOUND_STRING("ULTRA BALL"),
+        COMPOUND_STRING("PREMIER BALL"),
+        COMPOUND_STRING("DIVE BALL"),
+        COMPOUND_STRING("DUSK BALL"),
+        COMPOUND_STRING("TIMER BALL"),
+        COMPOUND_STRING("QUICK BALL"),
+        COMPOUND_STRING("CHERISH BALL"),
+        COMPOUND_STRING("BEAST BALL"),
+        gText_Exit
     }
 };
 


### PR DESCRIPTION
## Summary
- Add scrollable menu constants and options for EVs, IVs, stats, and balls
- Extend ScrollableMultichoice handler for new QoL menus
- Update QoL Scientist scripts to use scrollable lists instead of basic multichoice menus

## Testing
- `make test` *(fails: arm-none-eabi-cpp: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19fe804088323a02a26b7d3fb2377