### PR TITLE
feat: add paged hidden power type table

### DIFF
--- a/data/scripts/qol_scientist.inc
+++ b/data/scripts/qol_scientist.inc
@@ -337,15 +337,64 @@ EventScript_QoLScientist::
     special ChoosePartyMon
     waitstate
     goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, .MainLoop
-	msgbox gText_QoLPickHPType, MSGBOX_DEFAULT
-	multichoice 0, 0, MULTI_QOL_HP_TYPES, FALSE
-	compare VAR_RESULT, 16
-	goto_if_eq .MainLoop
-	setvar VAR_0x8000, TYPE_FIGHTING
-	addvar VAR_0x8000, VAR_RESULT
-	callnative Script_QoL_SetHiddenPowerType
-	call .ResultMsg
-	goto .MainLoop
+    copyvar VAR_0x8006, VAR_0x8004 @ preserve chosen slot for HP edits
+    @ Page 1 of Hidden Power types
+.HPPage1:
+    setvar VAR_0x8004, SCROLL_MULTI_QOL_HP_TYPES_PAGE1
+    special ShowScrollableMultichoice
+    waitstate
+    switch VAR_RESULT
+            case 0, .HPSetFighting
+            case 1, .HPSetFlying
+            case 2, .HPSetPoison
+            case 3, .HPSetGround
+            case 4, .HPSetRock
+            case 5, .HPSetBug
+            case 6, .HPSetGhost
+            case 7, .HPSetSteel
+            case 8, .HPPage2
+            case MULTI_B_PRESSED, .MainLoop
+    end
+
+.HPPage2:
+    setvar VAR_0x8004, SCROLL_MULTI_QOL_HP_TYPES_PAGE2
+    special ShowScrollableMultichoice
+    waitstate
+    switch VAR_RESULT
+            case 0, .HPSetFire
+            case 1, .HPSetWater
+            case 2, .HPSetGrass
+            case 3, .HPSetElectric
+            case 4, .HPSetPsychic
+            case 5, .HPSetIce
+            case 6, .HPSetDragon
+            case 7, .HPSetDark
+            case 8, .HPPage1
+            case MULTI_B_PRESSED, .MainLoop
+    end
+
+.HPSetFighting: setvar VAR_0x8000, TYPE_FIGHTING; goto .HPApply
+.HPSetFlying:   setvar VAR_0x8000, TYPE_FLYING;   goto .HPApply
+.HPSetPoison:   setvar VAR_0x8000, TYPE_POISON;   goto .HPApply
+.HPSetGround:   setvar VAR_0x8000, TYPE_GROUND;   goto .HPApply
+.HPSetRock:     setvar VAR_0x8000, TYPE_ROCK;     goto .HPApply
+.HPSetBug:      setvar VAR_0x8000, TYPE_BUG;      goto .HPApply
+.HPSetGhost:    setvar VAR_0x8000, TYPE_GHOST;    goto .HPApply
+.HPSetSteel:    setvar VAR_0x8000, TYPE_STEEL;    goto .HPApply
+.HPSetFire:     setvar VAR_0x8000, TYPE_FIRE;     goto .HPApply
+.HPSetWater:    setvar VAR_0x8000, TYPE_WATER;    goto .HPApply
+.HPSetGrass:    setvar VAR_0x8000, TYPE_GRASS;    goto .HPApply
+.HPSetElectric: setvar VAR_0x8000, TYPE_ELECTRIC; goto .HPApply
+.HPSetPsychic:  setvar VAR_0x8000, TYPE_PSYCHIC;  goto .HPApply
+.HPSetIce:      setvar VAR_0x8000, TYPE_ICE;      goto .HPApply
+.HPSetDragon:   setvar VAR_0x8000, TYPE_DRAGON;   goto .HPApply
+.HPSetDark:     setvar VAR_0x8000, TYPE_DARK;     goto .HPApply
+
+.HPApply:
+    copyvar VAR_0x8004, VAR_0x8006 @ restore chosen slot for callnative
+    callnative Script_QoL_SetHiddenPowerType
+    call .ResultMsg
+    goto .MainLoop
 
 .ResultMsg:
 	compare VAR_RESULT, 1

--- a/include/constants/field_specials.h
+++ b/include/constants/field_specials.h
@@ -59,7 +59,8 @@
 #define SCROLL_MULTI_QOL_IVS                              29
 #define SCROLL_MULTI_QOL_STATS                            30
 #define SCROLL_MULTI_QOL_BALLS                            31
-#define SCROLL_MULTI_QOL_HP_TYPES                         32
+#define SCROLL_MULTI_QOL_HP_TYPES_PAGE1                   32
+#define SCROLL_MULTI_QOL_HP_TYPES_PAGE2                   33
 
 #define MAX_SCROLL_MULTI_ON_SCREEN 6
 #define MAX_SCROLL_MULTI_LENGTH 17

--- a/include/constants/script_menu.h
+++ b/include/constants/script_menu.h
@@ -131,7 +131,6 @@
 #define MULTI_QOL_STATS                    118
 #define MULTI_QOL_BALLS                    119
 #define MULTI_QOL_NATURES                  120
-#define MULTI_QOL_HP_TYPES                 121
 
 // Lilycove SS Tidal Multichoice Selections
 #define SSTIDAL_SELECTION_SLATEPORT        0

--- a/src/data/script_menu.h
+++ b/src/data/script_menu.h
@@ -662,13 +662,6 @@ static const struct MenuAction MultichoiceList_QoL_Natures[] =
     { COMPOUND_STRING("CALM") }, { COMPOUND_STRING("GENTLE") }, { COMPOUND_STRING("SASSY") }, { COMPOUND_STRING("CAREFUL") }, { COMPOUND_STRING("QUIRKY") },
 };
 
-static const struct MenuAction MultichoiceList_QoL_HpTypes[] =
-{
-    { COMPOUND_STRING("FIGHTING") }, { COMPOUND_STRING("FLYING") }, { COMPOUND_STRING("POISON") }, { COMPOUND_STRING("GROUND") },
-    { COMPOUND_STRING("ROCK") }, { COMPOUND_STRING("BUG") }, { COMPOUND_STRING("GHOST") }, { COMPOUND_STRING("STEEL") },
-    { COMPOUND_STRING("FIRE") }, { COMPOUND_STRING("WATER") }, { COMPOUND_STRING("GRASS") }, { COMPOUND_STRING("ELECTRIC") },
-    { COMPOUND_STRING("PSYCHIC") }, { COMPOUND_STRING("ICE") }, { COMPOUND_STRING("DRAGON") }, { COMPOUND_STRING("DARK") }, { gText_Exit },
-};
 
 static const struct MenuAction MultichoiceList_Fossil[] =
 {
@@ -984,7 +977,6 @@ static const struct MultichoiceListStruct sMultichoiceLists[] =
     [MULTI_QOL_STATS]                  = MULTICHOICE(MultichoiceList_QoL_Stats),
     [MULTI_QOL_BALLS]                  = MULTICHOICE(MultichoiceList_QoL_Balls),
     [MULTI_QOL_NATURES]                = MULTICHOICE(MultichoiceList_QoL_Natures),
-    [MULTI_QOL_HP_TYPES]               = MULTICHOICE(MultichoiceList_QoL_HpTypes),
 };
 
 const u8 *const gStdStrings[] =

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2641,11 +2641,21 @@ void ShowScrollableMultichoice(void)
         task->tKeepOpenAfterSelect = FALSE;
         task->tTaskId = taskId;
         break;
-    case SCROLL_MULTI_QOL_HP_TYPES:
+    case SCROLL_MULTI_QOL_HP_TYPES_PAGE1:
         task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
-        task->tNumItems = 17;
-        task->tLeft = 0;
-        task->tTop = 0;
+        task->tNumItems = 9; // 8 types + Next
+        task->tLeft = 15;
+        task->tTop = 1;
+        task->tWidth = 14;
+        task->tHeight = 12;
+        task->tKeepOpenAfterSelect = FALSE;
+        task->tTaskId = taskId;
+        break;
+    case SCROLL_MULTI_QOL_HP_TYPES_PAGE2:
+        task->tMaxItemsOnScreen = MAX_SCROLL_MULTI_ON_SCREEN;
+        task->tNumItems = 9; // 8 types + Back
+        task->tLeft = 15;
+        task->tTop = 1;
         task->tWidth = 14;
         task->tHeight = 12;
         task->tKeepOpenAfterSelect = FALSE;
@@ -3025,25 +3035,29 @@ static const u8 *const sScrollableMultichoiceOptions[][MAX_SCROLL_MULTI_LENGTH] 
         COMPOUND_STRING("BEAST BALL"),
         gText_Exit
     },
-    [SCROLL_MULTI_QOL_HP_TYPES] =
+    [SCROLL_MULTI_QOL_HP_TYPES_PAGE1] =
     {
-        COMPOUND_STRING("FIGHTING"),
-        COMPOUND_STRING("FLYING"),
-        COMPOUND_STRING("POISON"),
-        COMPOUND_STRING("GROUND"),
-        COMPOUND_STRING("ROCK"),
-        COMPOUND_STRING("BUG"),
-        COMPOUND_STRING("GHOST"),
-        COMPOUND_STRING("STEEL"),
-        COMPOUND_STRING("FIRE"),
-        COMPOUND_STRING("WATER"),
-        COMPOUND_STRING("GRASS"),
-        COMPOUND_STRING("ELECTRIC"),
-        COMPOUND_STRING("PSYCHIC"),
-        COMPOUND_STRING("ICE"),
-        COMPOUND_STRING("DRAGON"),
-        COMPOUND_STRING("DARK"),
-        gText_Exit
+        COMPOUND_STRING("FIGHTING{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("FLYING{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("POISON{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("GROUND{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("ROCK{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("BUG{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("GHOST{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("STEEL{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("NEXT"),
+    },
+    [SCROLL_MULTI_QOL_HP_TYPES_PAGE2] =
+    {
+        COMPOUND_STRING("FIRE{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("WATER{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("GRASS{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("ELECTRIC{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("PSYCHIC{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("ICE{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("DRAGON{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("DARK{CLEAR_TO 0x48}¥1000"),
+        COMPOUND_STRING("BACK"),
     }
 };
 


### PR DESCRIPTION
## Summary
- split hidden power type list into two paged tables with costs like tera type selection
- remove obsolete multichoice list for hidden power types
- preserve selected party slot when choosing hidden power type

## Testing
- `make -j2` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ae0b6f848323a08ec36d9cc4b6e6