### PR TITLE
Add reusable quantity selector and online store prompt

### DIFF
--- a/include/online_store.h
+++ b/include/online_store.h
@@ -188,5 +188,6 @@ bool32 AddToCart(u16 itemId, u16 quantity);
 u32 CartGetTotalCost(void);
 bool32 CartWillFitInBag(void);
 void OnlineStore_StartCheckout(void);
+void Store_QtyPrompt(u16 itemId);
 
 #endif // GUARD_ONLINE_STORE_H

--- a/include/shop.h
+++ b/include/shop.h
@@ -10,4 +10,7 @@ void CreateDecorationShop1Menu(const u16 *itemsForSale);
 void CreateDecorationShop2Menu(const u16 *itemsForSale);
 void CB2_ExitSellMenu(void);
 
+// Reusable quantity selector used by marts and the online store.
+void Shop_DoQuantitySelect(u16 maxQuantity, void (*onConfirm)(u16), void (*onCancel)(void));
+
 #endif // GUARD_SHOP_H


### PR DESCRIPTION
## Summary
- Expose `Shop_DoQuantitySelect` for quantity input with confirm/cancel callbacks
- Add `Store_QtyPrompt` to compute bag limits and add items to cart via the selector

## Testing
- `make` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21895060483239802e0120f1622a5