### PR TITLE
Add StringContains utility and use in online store category

### DIFF
--- a/include/string_util.h
+++ b/include/string_util.h
@@ -25,6 +25,7 @@ u16 StringLength(const u8 *str);
 u16 StringLineLength(const u8 *str);
 s32 StringCompare(const u8 *str1, const u8 *str2);
 s32 StringCompareN(const u8 *str1, const u8 *str2, u32 n);
+bool8 StringContains(const u8 *haystack, const u8 *needle);
 bool8 IsStringLengthAtLeast(const u8 *str, s32 n);
 u8 *ConvertIntToDecimalStringN(u8 *dest, s32 value, enum StringConvertMode mode, u8 n);
 u8 *ConvertUIntToDecimalStringN(u8 *dest, u32 value, enum StringConvertMode mode, u8 n);

--- a/src/online_store_categories.c
+++ b/src/online_store_categories.c
@@ -1,6 +1,11 @@
 #include "global.h"
 #include "item.h"
 #include "online_store.h"
+#include "string_util.h"
+#include "data.h"
+#include "constants/pokemon.h"
+
+extern const struct TypeInfo gTypesInfo[NUMBER_OF_MON_TYPES];
 
 static const u8 sCategoryName_Balls[] = _("Pok\xE9 Balls");
 static const u8 sCategoryName_Medicine[] = _("Medicine");
@@ -19,6 +24,20 @@ static bool8 IsMedicine(u16 itemId)
 static bool8 IsTMTR(u16 itemId)
 {
     return gItemsInfo[itemId].pocket == POCKET_TM_HM;
+}
+
+static bool8 IsTypeFormItem(u16 itemId)
+{
+    const u8 *name = ItemId_GetName(itemId);
+    u8 i;
+
+    for (i = 0; i < NUMBER_OF_MON_TYPES; i++)
+    {
+        if (StringContains(name, gTypesInfo[i].name))
+            return TRUE;
+    }
+
+    return FALSE;
 }
 
 const struct OnlineStoreCategory gOnlineStoreCategories[] =

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -174,6 +174,33 @@ s32 StringCompareN(const u8 *str1, const u8 *str2, u32 n)
     return *str1 - *str2;
 }
 
+bool8 StringContains(const u8 *haystack, const u8 *needle)
+{
+    const u8 *h, *n;
+
+    if (*needle == EOS)
+        return TRUE;
+
+    while (*haystack != EOS)
+    {
+        h = haystack;
+        n = needle;
+
+        while (*h != EOS && *n != EOS && *h == *n)
+        {
+            h++;
+            n++;
+        }
+
+        if (*n == EOS)
+            return TRUE;
+
+        haystack++;
+    }
+
+    return FALSE;
+}
+
 bool8 IsStringLengthAtLeast(const u8 *str, s32 n)
 {
     s32 i;


### PR DESCRIPTION
## Summary
- add a basic `StringContains` helper for substring checks
- leverage `StringContains` in `IsTypeFormItem` to scan item names for type terms

## Testing
- `make -j4` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24378230883239093c4ba2bcf8092