### PR TITLE
Add dynamic item categories for online store

### DIFF
--- a/src/online_store_categories.c
+++ b/src/online_store_categories.c
@@ -1,36 +1,47 @@
 #include "global.h"
 #include "item.h"
 #include "online_store.h"
-#include "string_util.h"
-#include "data.h"
-#include "constants/pokemon.h"
+#include "config/online_store.h"
 
-extern const struct TypeInfo gTypesInfo[NUMBER_OF_MON_TYPES];
-
-static const u8 sCategoryName_Balls[] = _("Poke Balls");
+static const u8 sCategoryName_Items[]    = _("Items");
 static const u8 sCategoryName_Medicine[] = _("Medicine");
-static const u8 sCategoryName_TMTR[] = _("TMs/TRs");
+static const u8 sCategoryName_Battle[]   = _("Battle Items");
+static const u8 sCategoryName_Balls[]    = _("Poke Balls");
+static const u8 sCategoryName_TMHM[]     = _("TMs/TRs");
+static const u8 sCategoryName_Berries[]  = _("Berries");
+static const u8 sCategoryName_KeyItems[] = _("Key Items");
 
-static bool8 IsBall(u16 itemId)
-{
-    return gItemsInfo[itemId].pocket == POCKET_POKE_BALLS;
-}
-
-static bool8 IsMedicine(u16 itemId)
-{
-    return gItemsInfo[itemId].pocket == POCKET_MEDICINE;
-}
-
-static bool8 IsTMTR(u16 itemId)
-{
-    return gItemsInfo[itemId].pocket == POCKET_TM_HM;
-}
+static bool8 IsItem(u16 itemId)     { return gItemsInfo[itemId].pocket == POCKET_ITEMS; }
+static bool8 IsMedicine(u16 itemId) { return gItemsInfo[itemId].pocket == POCKET_MEDICINE; }
+static bool8 IsBattle(u16 itemId)   { return gItemsInfo[itemId].pocket == POCKET_BATTLE_ITEMS; }
+static bool8 IsBall(u16 itemId)     { return gItemsInfo[itemId].pocket == POCKET_POKE_BALLS; }
+static bool8 IsTMHM(u16 itemId)     { return gItemsInfo[itemId].pocket == POCKET_TM_HM; }
+static bool8 IsBerry(u16 itemId)    { return gItemsInfo[itemId].pocket == POCKET_BERRIES; }
+static bool8 IsKeyItem(u16 itemId)  { return gItemsInfo[itemId].pocket == POCKET_KEY_ITEMS; }
 
 const struct OnlineStoreCategory gOnlineStoreCategories[] =
 {
-    [ONLINE_STORE_CATEGORY_BALLS] = { sCategoryName_Balls,    IsBall },
-    [ONLINE_STORE_CATEGORY_MEDICINE] = { sCategoryName_Medicine, IsMedicine },
-    [ONLINE_STORE_CATEGORY_TMTR] = { sCategoryName_TMTR,     IsTMTR },
+#if ONLINE_STORE_CATEGORY_ITEMS
+    { sCategoryName_Items,    IsItem },
+#endif
+#if ONLINE_STORE_CATEGORY_MEDICINE
+    { sCategoryName_Medicine, IsMedicine },
+#endif
+#if ONLINE_STORE_CATEGORY_BATTLE_ITEMS
+    { sCategoryName_Battle,   IsBattle },
+#endif
+#if ONLINE_STORE_CATEGORY_BALLS
+    { sCategoryName_Balls,    IsBall },
+#endif
+#if ONLINE_STORE_CATEGORY_TMHM
+    { sCategoryName_TMHM,     IsTMHM },
+#endif
+#if ONLINE_STORE_CATEGORY_BERRIES
+    { sCategoryName_Berries,  IsBerry },
+#endif
+#if ONLINE_STORE_CATEGORY_KEY_ITEMS
+    { sCategoryName_KeyItems, IsKeyItem },
+#endif
 };
 
 const u8 gOnlineStoreCategoryCount = ARRAY_COUNT(gOnlineStoreCategories);


### PR DESCRIPTION
## Summary
- Generate store categories dynamically by item pocket
- Support items, medicine, battle items, balls, TM/TRs, berries, and key items

## Testing
- `apt-get update`
- `apt-get install -y gcc-arm-none-eabi`
- `make` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f94ec7608323a3e028e568ddd413